### PR TITLE
Added unistd.h to XBTFriter.h for gcc-4.7 compatibility

### DIFF
--- a/tools/TexturePacker/XBTFWriter.h
+++ b/tools/TexturePacker/XBTFWriter.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <stdio.h>
+#include <unistd.h>
 #include "XBTF.h"
 
 class CXBTFWriter


### PR DESCRIPTION
Small patch for gcc-4.7 support.  This plus the libgcc patches previously submitted all compilation on Fedora 17.

Description of the change:
http://gcc.gnu.org/gcc-4.7/porting_to.html

Many of the standard C++ library include files have been edited to no longer include <unistd.h> to remove namespace pollution.  As such, C++ programs that used functions including truncate, sleep or pipe without first including <unistd.h> will no longer compile. The diagnostic produced is similar to: 
Fixing this issue is easy: just include <unistd.h>.
